### PR TITLE
Remove usage of `any` in typing

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
   "auto": {
     "plugins": [
       "npm"
-    ],
-    "onlyPublishWithReleaseLabel": true
+    ]
   }
 }

--- a/src/SuperTestGraphQL.ts
+++ b/src/SuperTestGraphQL.ts
@@ -178,7 +178,7 @@ export default class SuperTestGraphQL<TData, TVariables extends Variables>
           value: SuperTestExecutionResult<TData>
         ) => TResult1 | PromiseLike<TResult1>)
       | null,
-    onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | null
+    onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null
   ): Promise<TResult1 | TResult2> {
     try {
       if (this._query === undefined)

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import SuperTestGraphQL, { Variables } from "./SuperTestGraphQL";
  * Test against the given `app` returnig a new `SuperTestGraphQL`.
  */
 const supertest = <TData, TVariables extends Variables = Variables>(
-  app: any
+  app: unknown
 ): SuperTestGraphQL<TData, TVariables> => {
   const supertest = agent(app);
   return new SuperTestGraphQL<TData, TVariables>(supertest);


### PR DESCRIPTION
replaced them by `unknown`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.0.1--canary.3.1595028265.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install supertest-graphql@1.0.1--canary.3.1595028265.0
  # or 
  yarn add supertest-graphql@1.0.1--canary.3.1595028265.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
